### PR TITLE
Fix missing metadata routes for vultr (#1125)

### DIFF
--- a/cloudinit/distros/__init__.py
+++ b/cloudinit/distros/__init__.py
@@ -228,7 +228,12 @@ class Distro(persistence.CloudInitPickleMixin, metaclass=abc.ABCMeta):
         # Now try to bring them up
         if bring_up:
             LOG.debug('Bringing up newly configured network interfaces')
-            network_activator = activators.select_activator()
+            try:
+                network_activator = activators.select_activator()
+            except activators.NoActivatorException:
+                LOG.warning("No network activator found, not bringing up "
+                            "network interfaces")
+                return True
             network_activator.bring_up_all_interfaces(network_state)
         else:
             LOG.debug("Not bringing up newly configured network interfaces")

--- a/cloudinit/net/activators.py
+++ b/cloudinit/net/activators.py
@@ -16,6 +16,10 @@ from cloudinit.net.sysconfig import NM_CFG_FILE
 LOG = logging.getLogger(__name__)
 
 
+class NoActivatorException(Exception):
+    pass
+
+
 def _alter_interface(cmd, device_name) -> bool:
     LOG.debug("Attempting command %s for device %s", cmd, device_name)
     try:
@@ -271,7 +275,7 @@ def select_activator(priority=None, target=None) -> Type[NetworkActivator]:
         tmsg = ""
         if target and target != "/":
             tmsg = " in target=%s" % target
-        raise RuntimeError(
+        raise NoActivatorException(
             "No available network activators found%s. Searched "
             "through list: %s" % (tmsg, priority))
     selected = found[0]

--- a/cloudinit/sources/tests/test_lxd.py
+++ b/cloudinit/sources/tests/test_lxd.py
@@ -42,15 +42,12 @@ LXD_V1_METADATA = {
     "network-config": NETWORK_V1,
     "user-data": "#cloud-config\npackages: [sl]\n",
     "vendor-data": "#cloud-config\nruncmd: ['echo vendor-data']\n",
-    "1.0": {
-        "meta-data": "instance-id: my-lxc\nlocal-hostname: my-lxc\n\n",
-        "config": {
-            "user.user-data":
-                "instance-id: my-lxc\nlocal-hostname: my-lxc\n\n",
-            "user.vendor-data":
-                "#cloud-config\nruncmd: ['echo vendor-data']\n",
-            "user.network-config": yaml.safe_dump(NETWORK_V1),
-        }
+    "config": {
+        "user.user-data":
+            "instance-id: my-lxc\nlocal-hostname: my-lxc\n\n",
+        "user.vendor-data":
+            "#cloud-config\nruncmd: ['echo vendor-data']\n",
+        "user.network-config": yaml.safe_dump(NETWORK_V1),
     }
 }
 
@@ -190,8 +187,10 @@ class TestReadMetadata:
                     "http://lxd/1.0/meta-data": "local-hostname: md\n",
                     "http://lxd/1.0/config": "[]",
                 },
-                {"1.0": {"config": {}, "meta-data": "local-hostname: md\n"},
-                 "meta-data": "local-hostname: md\n"},
+                {
+                    "_metadata_api_version": lxd.LXD_SOCKET_API_VERSION,
+                    "config": {}, "meta-data": "local-hostname: md\n"
+                },
                 ["[GET] [HTTP:200] http://lxd/1.0/meta-data",
                  "[GET] [HTTP:200] http://lxd/1.0/config"],
             ),
@@ -211,12 +210,10 @@ class TestReadMetadata:
                     "http://lxd/1.0/config/user.vendor-data": "",  # 404
                 },
                 {
-                    "1.0": {
-                        "config": {
-                            "user.custom1": "custom1",   # Not promoted
-                            "user.network-config": "net-config",
-                        },
-                        "meta-data": "local-hostname: md\n",
+                    "_metadata_api_version": lxd.LXD_SOCKET_API_VERSION,
+                    "config": {
+                        "user.custom1": "custom1",   # Not promoted
+                        "user.network-config": "net-config",
                     },
                     "meta-data": "local-hostname: md\n",
                     "network-config": "net-config",
@@ -250,15 +247,13 @@ class TestReadMetadata:
                     "http://lxd/1.0/config/user.vendor-data": "vendor-data",
                 },
                 {
-                    "1.0": {
-                        "config": {
-                            "user.custom1": "custom1",   # Not promoted
-                            "user.meta-data": "meta-data",
-                            "user.network-config": "net-config",
-                            "user.user-data": "user-data",
-                            "user.vendor-data": "vendor-data",
-                        },
-                        "meta-data": "local-hostname: md\n",
+                    "_metadata_api_version": lxd.LXD_SOCKET_API_VERSION,
+                    "config": {
+                        "user.custom1": "custom1",   # Not promoted
+                        "user.meta-data": "meta-data",
+                        "user.network-config": "net-config",
+                        "user.user-data": "user-data",
+                        "user.vendor-data": "vendor-data",
                     },
                     "meta-data": "local-hostname: md\n",
                     "network-config": "net-config",
@@ -303,19 +298,17 @@ class TestReadMetadata:
                         "cloud-init.vendor-data",
                 },
                 {
-                    "1.0": {
-                        "config": {
-                            "user.meta-data": "user.meta-data",
-                            "user.network-config": "user.network-config",
-                            "user.user-data": "user.user-data",
-                            "user.vendor-data": "user.vendor-data",
-                            "cloud-init.network-config":
-                                "cloud-init.network-config",
-                            "cloud-init.user-data": "cloud-init.user-data",
-                            "cloud-init.vendor-data":
-                                "cloud-init.vendor-data",
-                        },
-                        "meta-data": "local-hostname: md\n",
+                    "_metadata_api_version": lxd.LXD_SOCKET_API_VERSION,
+                    "config": {
+                        "user.meta-data": "user.meta-data",
+                        "user.network-config": "user.network-config",
+                        "user.user-data": "user.user-data",
+                        "user.vendor-data": "user.vendor-data",
+                        "cloud-init.network-config":
+                            "cloud-init.network-config",
+                        "cloud-init.user-data": "cloud-init.user-data",
+                        "cloud-init.vendor-data":
+                            "cloud-init.vendor-data",
                     },
                     "meta-data": "local-hostname: md\n",
                     "network-config": "cloud-init.network-config",

--- a/doc/rtd/topics/instancedata.rst
+++ b/doc/rtd/topics/instancedata.rst
@@ -530,12 +530,18 @@ Both user-data scripts and **#cloud-config** data support jinja template
 rendering.
 When the first line of the provided user-data begins with,
 **## template: jinja** cloud-init will use jinja to render that file.
-Any instance-data-sensitive.json variables are surfaced as dot-delimited
-jinja template variables because cloud-config modules are run as 'root'
-user.
+Any instance-data-sensitive.json variables are surfaced as jinja template
+variables because cloud-config modules are run as 'root' user.
 
+.. note::
+  cloud-init also provides jinja-safe key aliases for any instance-data.json
+  keys which contain jinja operator characters such as +, -, ., /, etc. Any
+  jinja operator will be replaced with underscores in the jinja-safe key
+  alias. This allows for cloud-init templates to use aliased variable
+  references which allow for jinja's dot-notation reference such as
+  ``{{ ds.v1_0.my_safe_key }}`` instead of ``{{ ds["v1.0"]["my/safe-key"] }}``.
 
-Below are some examples of providing these types of user-data:
+Below are some other examples of using jinja templates in user-data:
 
 * Cloud config calling home with the ec2 public hostname and availability-zone
 

--- a/tests/integration_tests/datasources/test_lxd_discovery.py
+++ b/tests/integration_tests/datasources/test_lxd_discovery.py
@@ -53,7 +53,9 @@ def test_lxd_datasource_discovery(client: IntegrationInstance):
     assert "lxd" == v1["platform"]
     assert "LXD socket API v. 1.0 (/dev/lxd/sock)" == v1["subplatform"]
     ds_cfg = json.loads(client.execute('cloud-init query ds').stdout)
-    assert ["config", "meta_data"] == sorted(list(ds_cfg["1.0"].keys()))
+    assert ["_doc", "_metadata_api_version", "config", "meta-data"] == sorted(
+        list(ds_cfg.keys())
+    )
     if (
         client.settings.PLATFORM == "lxd_vm" and
         ImageSpecification.from_os_image().release in ("xenial", "bionic")
@@ -62,15 +64,18 @@ def test_lxd_datasource_discovery(client: IntegrationInstance):
         # to start the lxd-agent.
         # https://github.com/canonical/pycloudlib/blob/main/pycloudlib/\
         #    lxd/defaults.py#L13-L27
-        lxd_config_keys = ["user.meta_data", "user.vendor_data"]
+        # Underscore-delimited aliases exist for any keys containing hyphens or
+        # dots.
+        lxd_config_keys = ["user.meta-data", "user.vendor-data"]
     else:
-        lxd_config_keys = ["user.meta_data"]
-    assert lxd_config_keys == list(ds_cfg["1.0"]["config"].keys())
+        lxd_config_keys = ["user.meta-data"]
+    assert "1.0" == ds_cfg["_metadata_api_version"]
+    assert lxd_config_keys == list(ds_cfg["config"].keys())
     assert {"public-keys": v1["public_ssh_keys"][0]} == (
-        yaml.safe_load(ds_cfg["1.0"]["config"]["user.meta_data"])
+        yaml.safe_load(ds_cfg["config"]["user.meta-data"])
     )
     assert (
-        "#cloud-config\ninstance-id" in ds_cfg["1.0"]["meta_data"]
+        "#cloud-config\ninstance-id" in ds_cfg["meta-data"]
     )
     # Assert NoCloud seed data is still present in cloud image metadata
     # This will start failing if we redact metadata templates from

--- a/tests/integration_tests/modules/test_combined.py
+++ b/tests/integration_tests/modules/test_combined.py
@@ -74,23 +74,16 @@ class TestCombined:
         """Test that final_message module works as expected.
 
         Also tests LP 1511485: final_message is silent.
-
-        It's possible that if this test is run within a minute or so of
-        midnight that we'll see a failure because the day in the logs
-        is different from the day specified in the test definition.
         """
         client = class_client
         log = client.read_from_file('/var/log/cloud-init.log')
-        # Get date on host rather than locally as our host could be in a
-        # wildly different timezone (or more likely recording UTC)
-        today = client.execute('date "+%a, %d %b %Y"')
         expected = (
-            'This is my final message!\n'
-            r'\d+\.\d+.*\n'
-            '{}.*\n'
-            'DataSource.*\n'
-            r'\d+\.\d+'
-        ).format(today)
+            "This is my final message!\n"
+            r"\d+\.\d+.*\n"
+            r"\w{3}, \d{2} \w{3} \d{4} \d{2}:\d{2}:\d{2} \+\d{4}\n"  # Datetime
+            "DataSource.*\n"
+            r"\d+\.\d+"
+        )
 
         assert re.search(expected, log)
 

--- a/tests/integration_tests/modules/test_jinja_templating.py
+++ b/tests/integration_tests/modules/test_jinja_templating.py
@@ -11,6 +11,7 @@ USER_DATA = """\
 runcmd:
   - echo {{v1.local_hostname}} > /var/tmp/runcmd_output
   - echo {{merged_cfg._doc}} >> /var/tmp/runcmd_output
+  - echo {{v1['local-hostname']}} >> /var/tmp/runcmd_output
 """
 
 
@@ -18,13 +19,16 @@ runcmd:
 def test_runcmd_with_variable_substitution(client: IntegrationInstance):
     """Test jinja substitution.
 
-    Ensure we can also substitute variables from instance-data-sensitive
-    LP: #1931392
+    Ensure underscore-delimited aliases exist for hyphenated key and
+    we can also substitute variables from instance-data-sensitive
+    LP: #1931392.
     """
+    hostname = client.execute('hostname').stdout.strip()
     expected = [
-        client.execute('hostname').stdout.strip(),
+        hostname,
         ('Merged cloud-init system config from /etc/cloud/cloud.cfg and '
-            '/etc/cloud/cloud.cfg.d/')
+            '/etc/cloud/cloud.cfg.d/'),
+        hostname
     ]
     output = client.read_from_file('/var/tmp/runcmd_output')
     verify_ordered_items_in_text(expected, output)

--- a/tests/unittests/test_builtin_handlers.py
+++ b/tests/unittests/test_builtin_handlers.py
@@ -5,6 +5,7 @@
 import copy
 import errno
 import os
+import pytest
 import shutil
 import tempfile
 from textwrap import dedent
@@ -281,17 +282,44 @@ class TestJinjaTemplatePartHandler(CiTestCase):
             self.logs.getvalue())
 
 
-class TestConvertJinjaInstanceData(CiTestCase):
+class TestConvertJinjaInstanceData:
 
-    def test_convert_instance_data_hyphens_to_underscores(self):
-        """Replace hyphenated keys with underscores in instance-data."""
-        data = {'hyphenated-key': 'hyphenated-val',
-                'underscore_delim_key': 'underscore_delimited_val'}
-        expected_data = {'hyphenated_key': 'hyphenated-val',
-                         'underscore_delim_key': 'underscore_delimited_val'}
-        self.assertEqual(
-            expected_data,
-            convert_jinja_instance_data(data=data))
+    @pytest.mark.parametrize(
+        "include_key_aliases,data,expected", (
+            (
+                False,
+                {'my-key': 'my-val'},
+                {'my-key': 'my-val'}
+            ),
+            (
+                True,
+                {'my-key': 'my-val'},
+                {'my-key': 'my-val', 'my_key': 'my-val'}
+            ),
+            (
+                False,
+                {'my.key': 'my.val'},
+                {'my.key': 'my.val'}
+            ),
+            (
+                True,
+                {'my.key': 'my.val'},
+                {'my.key': 'my.val', 'my_key': 'my.val'}
+            ),
+            (
+                True,
+                {'my/key': 'my/val'},
+                {'my/key': 'my/val', 'my_key': 'my/val'}
+            ),
+        )
+    )
+    def test_convert_instance_data_operators_to_underscores(
+        self, include_key_aliases, data, expected
+    ):
+        """Replace Jinja operators keys with underscores in instance-data."""
+        assert expected == convert_jinja_instance_data(
+            data=data, include_key_aliases=include_key_aliases
+        )
 
     def test_convert_instance_data_promotes_versioned_keys_to_top_level(self):
         """Any versioned keys are promoted as top-level keys
@@ -307,11 +335,10 @@ class TestConvertJinjaInstanceData(CiTestCase):
         expected_data.update({'v1key1': 'v1.1', 'v2key1': 'v2.1'})
 
         converted_data = convert_jinja_instance_data(data=data)
-        self.assertCountEqual(
-            ['ds', 'v1', 'v2', 'v1key1', 'v2key1'], converted_data.keys())
-        self.assertEqual(
-            expected_data,
-            converted_data)
+        assert sorted(['ds', 'v1', 'v2', 'v1key1', 'v2key1']) == sorted(
+            converted_data.keys()
+        )
+        assert expected_data == converted_data
 
     def test_convert_instance_data_most_recent_version_of_promoted_keys(self):
         """The most-recent versioned key value is promoted to top-level."""
@@ -324,9 +351,7 @@ class TestConvertJinjaInstanceData(CiTestCase):
              'key3': 'newer v2 key3'})
 
         converted_data = convert_jinja_instance_data(data=data)
-        self.assertEqual(
-            expected_data,
-            converted_data)
+        assert expected_data == converted_data
 
     def test_convert_instance_data_decodes_decode_paths(self):
         """Any decode_paths provided are decoded by convert_instance_data."""
@@ -336,9 +361,7 @@ class TestConvertJinjaInstanceData(CiTestCase):
 
         converted_data = convert_jinja_instance_data(
             data=data, decode_paths=('key1/subkey1',))
-        self.assertEqual(
-            expected_data,
-            converted_data)
+        assert expected_data == converted_data
 
 
 class TestRenderJinjaPayload(CiTestCase):
@@ -355,6 +378,7 @@ class TestRenderJinjaPayload(CiTestCase):
             DEBUG: Converted jinja variables
             {
              "hostname": "foo",
+             "instance-id": "iid",
              "instance_id": "iid",
              "v1": {
               "hostname": "foo"

--- a/tests/unittests/test_datasource/test_common.py
+++ b/tests/unittests/test_datasource/test_common.py
@@ -41,6 +41,7 @@ DEFAULT_LOCAL = [
     CloudSigma.DataSourceCloudSigma,
     ConfigDrive.DataSourceConfigDrive,
     DigitalOcean.DataSourceDigitalOcean,
+    GCE.DataSourceGCELocal,
     Hetzner.DataSourceHetzner,
     IBMCloud.DataSourceIBMCloud,
     LXD.DataSourceLXD,

--- a/tests/unittests/test_datasource/test_gce.py
+++ b/tests/unittests/test_datasource/test_gce.py
@@ -360,5 +360,29 @@ class TestDataSourceGCE(test_helpers.HttprettyTestCase):
         self.ds.publish_host_keys(hostkeys)
         m_readurl.assert_has_calls(readurl_expected_calls, any_order=True)
 
+    @mock.patch(
+        "cloudinit.sources.DataSourceGCE.EphemeralDHCPv4",
+        autospec=True,
+    )
+    @mock.patch(
+        "cloudinit.sources.DataSourceGCE.DataSourceGCELocal.fallback_interface"
+    )
+    def test_local_datasource_uses_ephemeral_dhcp(self, _m_fallback, m_dhcp):
+        _set_mock_metadata()
+        ds = DataSourceGCE.DataSourceGCELocal(
+            sys_cfg={}, distro=None, paths=None
+        )
+        ds._get_data()
+        assert m_dhcp.call_count == 1
+
+    @mock.patch(
+        "cloudinit.sources.DataSourceGCE.EphemeralDHCPv4",
+        autospec=True,
+    )
+    def test_datasource_doesnt_use_ephemeral_dhcp(self, m_dhcp):
+        _set_mock_metadata()
+        ds = DataSourceGCE.DataSourceGCE(sys_cfg={}, distro=None, paths=None)
+        ds._get_data()
+        assert m_dhcp.call_count == 0
 
 # vi: ts=4 expandtab

--- a/tests/unittests/test_net_activators.py
+++ b/tests/unittests/test_net_activators.py
@@ -12,7 +12,8 @@ from cloudinit.net.activators import (
     IfUpDownActivator,
     NetplanActivator,
     NetworkManagerActivator,
-    NetworkdActivator
+    NetworkdActivator,
+    NoActivatorException,
 )
 from cloudinit.net.network_state import parse_net_config_data
 from cloudinit.safeyaml import load
@@ -99,7 +100,7 @@ class TestSearchAndSelect:
         resp = search_activator()
         assert resp == []
 
-        with pytest.raises(RuntimeError):
+        with pytest.raises(NoActivatorException):
             select_activator()
 
 


### PR DESCRIPTION
Vultr uses 169.254.169.254 for the metadata server. Some distros are
having trouble with this on IPv6 only servers because the route is
not being assigned to the link-local interface by default as it is in
other distros. This change sets that route before attempting to fetch
the metadata avoiding the current issue.
